### PR TITLE
fix: add tsconfig.json with ignoreDeprecations set to 5.0

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "ignoreDeprecations": "5.0",
+    "baseUrl": ".",
+    "typeRoots": ["aibtcdev-skills/node_modules/@types"],
+    "types": ["node"],
+    "paths": {
+      "@scure/base": ["aibtcdev-skills/node_modules/@scure/base"],
+      "@scure/btc-signer": ["aibtcdev-skills/node_modules/@scure/btc-signer"],
+      "@noble/curves/*": ["aibtcdev-skills/node_modules/@noble/curves/*"],
+      "@noble/hashes/*": ["aibtcdev-skills/node_modules/@noble/hashes/*"]
+    }
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Summary
- `ignoreDeprecations: "6.0"` is not a valid value for TypeScript 5.x — it causes `tsc` to error with `Invalid value for '--ignoreDeprecations'`
- This PR adds `tsconfig.json` with the correct value `"5.0"`, which is valid for TS 5.9.3

## Test plan
- [ ] Run `bun run tsc --noEmit` — should exit with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)